### PR TITLE
Fix site title for about.md page template

### DIFF
--- a/src/routes/about.md
+++ b/src/routes/about.md
@@ -1,3 +1,7 @@
+<svelte:head>
+  <title>About</title>
+</svelte:head>
+
 # About
 
 This is an example of how you can have _markdown_ in page content!


### PR DESCRIPTION
👋 Hey Josh, this is a great little project you've got here! I've been been looking for a nice off the shelf static blog solution for a while and this one checked all of the buckets. `msdvex` is extremely nice to work with!

While casually navigating between pages, I realized that title on the about page doesn't update properly. I think it might be nice to include an example of how to set that since it may not be obvious to the casual observer how to modify `head` tags in a msdvex file.