### PR TITLE
add prerender.default to build html files for publish

### DIFF
--- a/svelte.config.js
+++ b/svelte.config.js
@@ -30,6 +30,7 @@ const config = {
 
 	kit: {
 		adapter: adapter(),
+		prerender: { default: true },
 
 		// Allows reading from files in the root directory. Necessary for loading the README on the homepage, but nothing else.
 		vite: {


### PR DESCRIPTION
As suggested by sveltekit, so the build folder has html files to start with. I was surprised that this is isn't on by default... it feels like a typo to me but feel free to close this if not!

Love this starter, just gave it a shot and it works fantastic [otherwise]. I was also able to update all dependencies with no issues 🎉 😸 

I found that using https://npm.im/gh-pages, I had to set up my deploy script like so:

```json
"predeploy": "npm run build && touch build/.nojekyll",
"deploy": "npx gh-pages -d build -b main --dotfiles"
```