### PR TITLE
SvelteKit 2.12: $app/stores deprecated

### DIFF
--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -1,10 +1,10 @@
 <!-- This page handles any error encountered by the site. -->
 <script>
-import { page } from '$app/stores'
+	import { page } from '$app/state';
 </script>
 
-<h2>{$page.status}</h2>
-<p class="subhead">{$page.error.message}</p>
+<h2>{page.status}</h2>
+<p class="subhead">{page.error.message}</p>
 
 <p><strong>Sorry!</strong> Maybe try one of these links?</p>
 <ul>


### PR DESCRIPTION
Summary

Migrated from the deprecated $app/stores to the new $app/state API introduced in SvelteKit 2.12. This change ensures compatibility with SvelteKit 3 and leverages the fine-grained state management provided by the Svelte 5 runes API.

Key Changes

Replaced $app/stores with $app/state.
Adjusted usage by removing $ prefixes.

Motivation

The migration aligns with SvelteKit's latest best practices and deprecation guidelines, ensuring future compatibility and improved state handling.

Please review and provide feedback!